### PR TITLE
fix(pkg): remove module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     },
     "./package.json": "./package.json"
   },
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
It is not standard and all modern tools support conditional exports from the `exports` field, so this can be removed.