### PR TITLE
chore(tsc): typescript 5 maintanence

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,13 +36,12 @@
   },
   "overrides": [
     {
-      "files": [
-        "./build.config.ts",
-        "./vitest.config.ts",
-        "./build/*.ts",
-        "./test/*.test.ts"
-      ],
+      "files": ["./build.config.ts", "./build/*.ts"],
       "parserOptions": { "project": "./tsconfig.build.json" }
+    },
+    {
+      "files": ["./vitest.config.ts", "./test/*.test.ts"],
+      "parserOptions": { "project": "./tsconfig.tests.json" }
     }
   ]
 }

--- a/build.config.ts
+++ b/build.config.ts
@@ -12,6 +12,7 @@ async function fileExists(fp: string) {
 }
 
 export default defineBuildConfig({
+  declaration: true,
   hooks: {
     async 'rollup:done'(ctx) {
       for (const buildEntry of ctx.buildEntries) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { createIntl } from '@formatjs/intl'
 import { test, expect, vi } from 'vitest'
-import { type Formatter, createFormatter } from '../dist'
+import { type Formatter, createFormatter } from '../dist/index.mjs'
 
 const now = new Date(2023, 0, 1, 0, 0, 0, 0).getTime()
 const second = 1_000

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,7 @@
     "strict": true,
     "strictBindCallApply": true,
 
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
 
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
   "references": [
     {
       "path": "./tsconfig.build.json"
+    },
+    {
+      "path": "./tsconfig.tests.json"
     }
   ]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -5,11 +5,11 @@
 
     "module": "ESNext",
 
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
 
     "esModuleInterop": true,
 
-    "types": ["node"]
+    "types": []
   },
-  "include": ["./build.config.ts", "./tsconfig.build.json"]
+  "include": ["./vitest.config.ts", "./test/*.test.ts", "./tsconfig.tests.json"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,11 +3,6 @@ import { defineConfig } from 'vitest/config'
 import tsconfig from './tsconfig.tests.json'
 
 export default defineConfig({
-  test: {
-    deps: {
-      registerNodeLoader: true,
-    },
-  },
   esbuild: {
     tsconfigRaw: tsconfig as any,
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
-import tsconfig from './tsconfig.build.json'
+import tsconfig from './tsconfig.tests.json'
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
- chore(deps): update devdependency typescript to v5
- build: set unbuild declaration option to `true`
- chore(tsc): split tests/build configs, enable verbatimModuleSyntax
- tests: import dist index by full path
- chore: disable vitest node loader
