### PR TITLE
feat: add rounding modes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,18 +29,28 @@
     "@typescript-eslint/no-extra-semi": "off",
     "indent": "off",
     "no-useless-constructor": "off",
-    "@typescript-eslint/no-useless-constructor": "warn"
+    "@typescript-eslint/no-useless-constructor": "warn",
+    "import/namespace": ["error", { "allowComputed": true }]
   },
   "parserOptions": {
     "project": "./tsconfig.json"
   },
   "overrides": [
     {
+      "files": ["./src/**/*.ts"],
+      "parserOptions": { "project": "./tsconfig.json" }
+    },
+    {
       "files": ["./build.config.ts", "./build/*.ts"],
       "parserOptions": { "project": "./tsconfig.build.json" }
     },
     {
-      "files": ["./vitest.config.ts", "./test/*.test.ts"],
+      "files": [
+        "./vitest.config.ts",
+        "./test/*.test.ts",
+        "./test/data/*.ts",
+        "./src/utils/*.ts"
+      ],
       "parserOptions": { "project": "./tsconfig.tests.json" }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -109,8 +109,37 @@ Describes a value within the time range that can be used as or converted to a ti
 
   **Default**: `['quarter']`
 
+- `roundingMode?` ([`RoundingMode`] or `null`)
+
+  Rounding mode to use when the resulting duration is not an integer (e.g., 4.7 seconds).
+
+  It is roughly equivalent to the `roundingMode` option for the [`Intl.NumberFormat`] API and accepts the following options:
+
+  - `ceil` — round towards positive infinity.
+  - `floor` — round towards negative infinity.
+  - `expand` — round away from 0.
+  - `trunc` — round towards 0.
+  - `halfCeil` — round values below or at half-increment towards positive infinity, and values above away from 0.
+  - `halfFloor` — round values below or at half-increment towards negative infinity, and values above away from 0.
+  - `halfExpand` — round values above or at half-increment away from 0, and values below towards 0.
+  - `halfTrunc` — round values below or at half-increment towards 0, and values above away from 0.
+  - `halfEven` — round values at half-increment towards the nearest even value, values above it away from 0, and values below it towards 0.
+
+  Value of `null` will use `Math.round`. This value is only kept for backward compatibility and will be removed in the next major release, in which `"halfExpand"` will be made the new default.
+
+  **Default**: `null`.
+
+[`Intl.NumberFormat`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
 [`Intl.DateTimeFormatOptions`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options
 [`Intl.RelativeTimeFormatUnit`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format#unit
+
+### `RoundingMode`
+
+[`RoundingMode`]: #roundingmode
+
+String literal for one of the supported rounding modes.
+
+**Possible values**: `"ceil"`, `"floor"`, `"expand"`, `"trunc"`, `"halfCeil"`, `"halfFloor"`, `"halfExpand"`, `"halfTrunc"`, `"halfEven"`.
 
 ## Acknowledgements
 

--- a/src/utils/rounding.ts
+++ b/src/utils/rounding.ts
@@ -1,0 +1,100 @@
+/* eslint-disable no-var, import/no-mutable-exports */
+
+// ICU calls "expand" "up" and "trunc" "down".
+
+/** @returns Always positive decimal part of the number. */
+var toDecimal = (value: number) => Math.abs(value % 1)
+
+var isEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON
+
+var isGreaterOrEqual = (a: number, b: number) => a > b || isEqual(a, b)
+
+var isEven = (value: number) => Math.abs(value) % 2 < 1
+
+var nonZero = (value: number) => (Object.is(value, -0) ? 0 : value)
+
+/** Round towards positive infinity. */
+var ceil = (value: number) => nonZero(Math.ceil(value))
+
+/** Round towards negative infinity. */
+var floor = (value: number) => nonZero(Math.floor(value))
+
+/** Round away from zero. */
+var expand = (value: number) => (value >= 0 ? ceil(value) : floor(value))
+
+/** Round toward zero. */
+var trunc = (value: number) => (value >= 0 ? floor(value) : ceil(value))
+
+/** Ties toward positive infinity */
+var halfCeil = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    return isGreaterOrEqual(decimal, 0.5) ? ceil(value) : floor(value)
+  } else {
+    return decimal > 0.5 ? floor(value) : ceil(value)
+  }
+}
+
+/** Ties toward negative infinity. */
+var halfFloor = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    return decimal > 0.5 ? ceil(value) : floor(value)
+  } else {
+    return isGreaterOrEqual(decimal, 0.5) ? floor(value) : ceil(value)
+  }
+}
+
+/** Ties away from zero. */
+var halfExpand = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    return isGreaterOrEqual(decimal, 0.5) ? ceil(value) : floor(value)
+  } else {
+    return isGreaterOrEqual(decimal, 0.5) ? floor(value) : ceil(value)
+  }
+}
+
+/** Ties towards zero. */
+var halfTrunc = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value > 0) {
+    return decimal > 0.5 ? ceil(value) : floor(value)
+  } else {
+    return decimal > 0.5 ? floor(value) : ceil(value)
+  }
+}
+
+var halfEven = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    if (isEqual(decimal, 0.5)) {
+      return isEven(value) ? floor(value) : ceil(value)
+    }
+
+    return decimal > 0.5 ? ceil(value) : floor(value)
+  } else {
+    if (isEqual(decimal, 0.5)) {
+      return isEven(value) ? ceil(value) : floor(value)
+    }
+
+    return decimal > 0.5 ? floor(value) : ceil(value)
+  }
+}
+
+export {
+  ceil,
+  floor,
+  expand,
+  trunc,
+  halfCeil,
+  halfFloor,
+  halfExpand,
+  halfTrunc,
+  halfEven,
+}

--- a/test/data/rounding-samples.ts
+++ b/test/data/rounding-samples.ts
@@ -1,0 +1,695 @@
+export default [
+  {
+    roundingMode: 'ceil',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 3,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 2,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 1,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: 0,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -1,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -2,
+      },
+    ],
+  },
+  {
+    roundingMode: 'floor',
+    samples: [
+      {
+        value: 2.9,
+        result: 2,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 1,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 0,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: -1,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -2,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -3,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'expand',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 3,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 2,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 1,
+      },
+      {
+        value: -0.2,
+        result: -1,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -2,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -3,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'trunc',
+    samples: [
+      {
+        value: 2.9,
+        result: 2,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 1,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 0,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: 0,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -1,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -2,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfCeil',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfFloor',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfExpand',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfTrunc',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfEven',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -139,4 +139,20 @@ test('formatTimeDifference (all units excluded)', () => {
   ).toBe('1 січня 2023 р. о 00:00')
 })
 
+test('formatTimeDifference (trunc rounding method)', () => {
+  const twoSthnYearsInPast = now - year * 2.7
+  const twoSthnYearsInFuture = now + year * 2.7
+
+  expect(ago(twoSthnYearsInPast)).toMatchInlineSnapshot('"3 роки тому"')
+  expect(ago(twoSthnYearsInFuture)).toMatchInlineSnapshot('"через 3 роки"')
+
+  expect(
+    ago(twoSthnYearsInPast, { roundingMode: 'trunc' }),
+  ).toMatchInlineSnapshot('"2 роки тому"')
+
+  expect(
+    ago(twoSthnYearsInFuture, { roundingMode: 'trunc' }),
+  ).toMatchInlineSnapshot('"через 2 роки"')
+})
+
 // TODO: more tests + coverage

--- a/test/rounding.test.ts
+++ b/test/rounding.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import * as roundingModesImpls from '../src/utils/rounding.ts'
+import roundingSamples from './data/rounding-samples.ts'
+
+type RoundingMode = keyof typeof roundingModesImpls
+
+describe('rounding modes', () => {
+  for (const { roundingMode, samples } of roundingSamples) {
+    it(`rounds correctly in "${roundingMode}"`, () => {
+      expect(
+        roundingModesImpls,
+        `${roundingMode} is implemented`,
+      ).toHaveProperty(roundingMode)
+
+      for (const { value, result } of samples) {
+        expect(
+          roundingModesImpls[roundingMode as RoundingMode](value),
+          `Value ${value} is rounded to ${result}`,
+        ).toEqual(result)
+      }
+    })
+  }
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,8 +7,6 @@
     "strict": true,
     "strictBindCallApply": true,
 
-    "verbatimModuleSyntax": true,
-
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "esnext",
     "moduleResolution": "bundler",
 
+    "allowImportingTsExtensions": true,
+
     "types": [],
 
     "outDir": "./dist",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -3,9 +3,21 @@
   "compilerOptions": {
     "composite": true,
 
-    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
 
-    "types": []
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+
+    "types": [],
+
+    "emitDeclarationOnly": true
   },
-  "include": ["./vitest.config.ts", "./test/*.test.ts", "./tsconfig.tests.json"]
+  "include": [
+    "./vitest.config.ts",
+    "./test/*.test.ts",
+    "./test/data/*.ts",
+    "./tsconfig.tests.json",
+    "./src/utils/*.ts"
+  ]
 }


### PR DESCRIPTION
Adds an option to specify a rounding mode, similar to one found in `Intl.NumberFormat` API. That mode is used to round non-integer durations.

To avoid creaitng a breaking and rather unexpected change, `roundingMode` accepts and is `null` by default.

However, in the future major update this default will be changed to `halfExpand`. Meaning that durations (𝑥) which equal or is halway through increment (0.5), will be rounded to the next integer away from 0 after 𝑥; divisions below that will be rounded to the next integer towards 0 after 𝑥.

This, of course, can be changed to any suitable mode, e.g., `trunc`, which would round all durations (𝑥) to the next integer towards 0.