### PR TITLE
chore(eslint): get rid of non-functional cache

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,18 +29,28 @@
     "@typescript-eslint/no-extra-semi": "off",
     "indent": "off",
     "no-useless-constructor": "off",
-    "@typescript-eslint/no-useless-constructor": "warn"
+    "@typescript-eslint/no-useless-constructor": "warn",
+    "import/namespace": ["error", { "allowComputed": true }]
   },
   "parserOptions": {
     "project": "./tsconfig.json"
   },
   "overrides": [
     {
+      "files": ["./src/**/*.ts"],
+      "parserOptions": { "project": "./tsconfig.json" }
+    },
+    {
       "files": ["./build.config.ts", "./build/*.ts"],
       "parserOptions": { "project": "./tsconfig.build.json" }
     },
     {
-      "files": ["./vitest.config.ts", "./test/*.test.ts"],
+      "files": [
+        "./vitest.config.ts",
+        "./test/*.test.ts",
+        "./test/data/*.ts",
+        "./src/utils/*.ts"
+      ],
       "parserOptions": { "project": "./tsconfig.tests.json" }
     }
   ]

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -43,14 +43,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - uses: actions/cache@v3
-        name: Setup ESLint cache
-        with:
-          path: .eslintcache
-          key: ${{ runner.os }}-eslint-${{ hashFiles('**/pnpm-lock.yaml', '.eslintignore', '.eslintrc.json', 'tsconfig.json', 'tsconfig.*.json') }}
-          restore-keys: |
-            ${{ runner.os }}-eslint-
-
       - name: Install dependencies
         run: pnpm install
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,37 @@ Describes a value within the time range that can be used as or converted to a ti
 
   **Default**: `['quarter']`
 
+- `roundingMode?` ([`RoundingMode`] or `null`)
+
+  Rounding mode to use when the resulting duration is not an integer (e.g., 4.7 seconds).
+
+  It is roughly equivalent to the `roundingMode` option for the [`Intl.NumberFormat`] API and accepts the following options:
+
+  - `ceil` — round towards positive infinity.
+  - `floor` — round towards negative infinity.
+  - `expand` — round away from 0.
+  - `trunc` — round towards 0.
+  - `halfCeil` — round values below or at half-increment towards positive infinity, and values above away from 0.
+  - `halfFloor` — round values below or at half-increment towards negative infinity, and values above away from 0.
+  - `halfExpand` — round values above or at half-increment away from 0, and values below towards 0.
+  - `halfTrunc` — round values below or at half-increment towards 0, and values above away from 0.
+  - `halfEven` — round values at half-increment towards the nearest even value, values above it away from 0, and values below it towards 0.
+
+  Value of `null` will use `Math.round`. This value is only kept for backward compatibility and will be removed in the next major release, in which `"halfExpand"` will be made the new default.
+
+  **Default**: `null`.
+
+[`Intl.NumberFormat`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
 [`Intl.DateTimeFormatOptions`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options
 [`Intl.RelativeTimeFormatUnit`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format#unit
+
+### `RoundingMode`
+
+[`RoundingMode`]: #roundingmode
+
+String literal for one of the supported rounding modes.
+
+**Possible values**: `"ceil"`, `"floor"`, `"expand"`, `"trunc"`, `"halfCeil"`, `"halfFloor"`, `"halfExpand"`, `"halfTrunc"`, `"halfEven"`.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Relative time with `@formatjs/intl` made easy.
 
-[![Supports: ESM only](https://img.shields.io/static/v1?label=Format&message=ESM%20only&color=blue&style=flat-square)](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) [![Depends on @formatjs/intl](https://img.shields.io/static/v1?label=Requires&message=%40formatjs%2Fintl&color=lightgray&style=flat-square)][formatjs_intl]
+[![Supports: ESM only.](https://img.shields.io/static/v1?label=Format&message=ESM%20only&color=blue&style=flat-square)](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) [![Depends on @formatjs/intl.](https://img.shields.io/static/v1?label=Requires&message=%40formatjs%2Fintl&color=lightgray&style=flat-square)][formatjs_intl] [![Support the author.](https://img.shields.io/static/v1?label=&message=Support+the+author&color=5E8C61&style=flat-square&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOCIgaGVpZ2h0PSIyOCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgY2xhc3M9Imx1Y2lkZSBsdWNpZGUtaGVhcnQiPjxwYXRoIGQ9Ik0xOSAxNGMxLjQ5LTEuNDYgMy0zLjIxIDMtNS41QTUuNSA1LjUgMCAwIDAgMTYuNSAzYy0xLjc2IDAtMyAuNS00LjUgMi0xLjUtMS41LTIuNzQtMi00LjUtMkE1LjUgNS41IDAgMCAwIDIgOC41YzAgMi4zIDEuNSA0LjA1IDMgNS41bDcgN1oiLz48L3N2Zz4%3D)](https://github.com/Brawaru/Brawaru/blob/main/SUPPORT.md)
 
 ## **Summary**
 
@@ -157,3 +157,9 @@ This implementation is based on [the implementation][omorphia_impl] from Modrint
 
 [Omorphia]: https://github.com/modrinth/omorphia/
 [omorphia_impl]: https://github.com/modrinth/omorphia/blob/87251878a582616d65301aa9881b3ac585ace97e/src/utils/ago.ts
+
+## Credits
+
+Made with 💜 by [Brawaru](https://github.com/brawaru). Released under [MIT Licence](./LICENSE).
+
+<a href="https://github.com/Brawaru/Brawaru/blob/main/SUPPORT.md"><img alt="Support me by donating" height="56" src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/donate/generic-singular_vector.svg"></a>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ Describes a value within the time range that can be used as or converted to a ti
 
   **Default**: `null`.
 
+- `unitRounding?` (`boolean`)
+
+  Whether to round to the nearest unit if the rounded duration goes above the threshold for the current unit.
+
+  For example, if 59.7 minutes round to 60 minutes, and this option is enabled, the duration will be rounded to use hour units, thus returning `"1 hour"`. Otherwise, the result of 60 minutes will be returned as is — `"60 minutes"`.
+
+  By default, this option is disabled (`false`) when the `roundingMode` is set to `null`, but enabled (`true`) otherwise. This will change in the next major update, in which this option will always be enabled (`true`) by default, regardless of the `roundingMode`.
+
+  **Default**: `false` (when `roundingMode` is `null`) or `true` (otherwise).
+
 [`Intl.NumberFormat`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
 [`Intl.DateTimeFormatOptions`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options
 [`Intl.RelativeTimeFormatUnit`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format#unit

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "vitest dev",
     "prepack": "pnpm run build",
     "test": "vitest run",
-    "lint": "eslint . --ext .js,.ts --cache",
+    "lint": "eslint . --ext .js,.ts",
     "bt": "pnpm run -s build && pnpm run -s test"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,12 +238,7 @@ function toTimeSpan(range: DateTimeRange): TimeSpan {
         : [range.from, range.to]
 
       start = toTimestamp(from)
-
-      if (to == null) {
-        end = Date.now()
-      } else {
-        end = toTimestamp(to)
-      }
+      end = to == null ? Date.now() : toTimestamp(to)
     }
   } else {
     start = toTimestamp(range)
@@ -258,16 +253,14 @@ function getExcludedUnits(options?: FormatOptions) {
 
   const optionsExcludedUnits = options?.excludedUnits
 
-  if (optionsExcludedUnits != null) {
-    if (Array.isArray(optionsExcludedUnits)) {
-      for (const unit of optionsExcludedUnits) excludedUnits.push(unit)
-    } else {
-      throw new TypeError(
-        'Value is not of array type for formatTimeDifference options property excludedUnits',
-      )
-    }
-  } else {
+  if (optionsExcludedUnits == null) {
     excludedUnits.push('quarter')
+  } else if (Array.isArray(optionsExcludedUnits)) {
+    for (const unit of optionsExcludedUnits) excludedUnits.push(unit)
+  } else {
+    throw new TypeError(
+      'Value is not of array type for formatTimeDifference options property excludedUnits',
+    )
   }
 
   return excludedUnits
@@ -278,22 +271,20 @@ function filterMatchers(options?: FormatOptions) {
 
   const excludedUnits = getExcludedUnits(options)
 
-  if (excludedUnits.length === 0) {
-    filteredMatchers = matchers
-  } else {
-    filteredMatchers = [...matchers]
+  if (excludedUnits.length === 0) return matchers
 
-    for (const unit of excludedUnits) {
-      const normalizedUnit = normalizeUnit(unit)
+  filteredMatchers = [...matchers]
 
-      const matcherToExcludeIndex = filteredMatchers.findIndex(
-        (matcher) => matcher[0] === normalizedUnit,
-      )
+  for (const unit of excludedUnits) {
+    const normalizedUnit = normalizeUnit(unit)
 
-      if (matcherToExcludeIndex === -1) throwRangeError('excludedUnits', unit)
+    const matcherToExcludeIndex = filteredMatchers.findIndex(
+      (matcher) => matcher[0] === normalizedUnit,
+    )
 
-      filteredMatchers.splice(matcherToExcludeIndex, 1)
-    }
+    if (matcherToExcludeIndex === -1) throwRangeError('excludedUnits', unit)
+
+    filteredMatchers.splice(matcherToExcludeIndex, 1)
   }
 
   return filteredMatchers

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,13 +261,11 @@ function getExcludedUnits({ excludedUnits }: FormatOptions) {
 }
 
 function filterMatchers(options: FormatOptions) {
-  let filteredMatchers: IntervalMatcher[]
-
   const excludedUnits = getExcludedUnits(options)
 
   if (excludedUnits.length === 0) return matchers
 
-  filteredMatchers = [...matchers]
+  const filteredMatchers = [...matchers]
 
   for (const unit of excludedUnits) {
     const normalizedUnit = normalizeUnit(unit)

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,25 +248,19 @@ function toTimeSpan(range: DateTimeRange): TimeSpan {
   return [start, end]
 }
 
-function getExcludedUnits(options?: FormatOptions) {
-  const excludedUnits: Intl.RelativeTimeFormatUnit[] = []
+function getExcludedUnits({ excludedUnits }: FormatOptions) {
+  if (excludedUnits == null) return ['quarter']
 
-  const optionsExcludedUnits = options?.excludedUnits
-
-  if (optionsExcludedUnits == null) {
-    excludedUnits.push('quarter')
-  } else if (Array.isArray(optionsExcludedUnits)) {
-    for (const unit of optionsExcludedUnits) excludedUnits.push(unit)
-  } else {
+  if (!Array.isArray(excludedUnits)) {
     throw new TypeError(
       'Value is not of array type for formatTimeDifference options property excludedUnits',
     )
   }
 
-  return excludedUnits
+  return [...excludedUnits]
 }
 
-function filterMatchers(options?: FormatOptions) {
+function filterMatchers(options: FormatOptions) {
   let filteredMatchers: IntervalMatcher[]
 
   const excludedUnits = getExcludedUnits(options)
@@ -292,24 +286,29 @@ function filterMatchers(options?: FormatOptions) {
 
 const unitNone = 'none'
 
-function getMinimumMaximumUnits(
-  options?: FormatOptions,
-): readonly [
+function getMinimumMaximumUnits({
+  minimumUnit,
+  maximumUnit,
+}: FormatOptions): readonly [
   minimumUnit: Intl.RelativeTimeFormatUnitSingular | 'none',
   maximumUnit: Intl.RelativeTimeFormatUnitSingular | 'none',
 ] {
-  let minUnit = options?.minimumUnit ?? unitNone
-  let maxUnit = options?.maximumUnit ?? unitNone
+  minimumUnit ??= unitNone
+  maximumUnit ??= unitNone
 
-  if (minUnit !== unitNone) {
-    minUnit = normalizeUnit(String(minUnit) as Intl.RelativeTimeFormatUnit)
+  if (minimumUnit !== unitNone) {
+    minimumUnit = normalizeUnit(
+      String(minimumUnit) as Intl.RelativeTimeFormatUnit,
+    )
   }
 
-  if (maxUnit !== unitNone) {
-    maxUnit = normalizeUnit(String(maxUnit) as Intl.RelativeTimeFormatUnit)
+  if (maximumUnit !== unitNone) {
+    maximumUnit = normalizeUnit(
+      String(maximumUnit) as Intl.RelativeTimeFormatUnit,
+    )
   }
 
-  return [minUnit, maxUnit] as const
+  return [minimumUnit, maximumUnit] as const
 }
 
 function throwRangeError(property: string, value: unknown): never {
@@ -372,8 +371,8 @@ function calculateBoundaries(
   return [minimumUnitMatcherIndex, maximumUnitMatcherIndex]
 }
 
-function getRoundingMethod(options?: FormatOptions) {
-  const roundingMode = options?.roundingMode ?? null
+function getRoundingMethod({ roundingMode }: FormatOptions) {
+  roundingMode ??= null
   if (roundingMode === null) return Math.round
   if (!Object.hasOwn(roundingModesImpls, roundingMode)) {
     throwRangeError('roundingMode', roundingMode)
@@ -381,10 +380,7 @@ function getRoundingMethod(options?: FormatOptions) {
   return roundingModesImpls[roundingMode]
 }
 
-function shouldUseUnitRounding({
-  unitRounding,
-  roundingMode,
-}: FormatOptions = {}) {
+function shouldUseUnitRounding({ unitRounding, roundingMode }: FormatOptions) {
   unitRounding ??= (roundingMode ?? null) !== null
   if (typeof unitRounding !== 'boolean') {
     throwRangeError('unitRounding', unitRounding)
@@ -396,7 +392,7 @@ function tryAsRelativeTime(
   formatRelativeTime: IntlFormatters['formatRelativeTime'],
   from: number,
   to: number,
-  options?: FormatOptions,
+  options: FormatOptions,
 ): string | null {
   const filteredMatchers = filterMatchers(options)
 
@@ -491,7 +487,7 @@ function formatRelativeTimeRange(
   formatRelativeTime: IntlFormatters<any>['formatRelativeTime'],
   formatDate: IntlFormatters<any>['formatDate'],
   range: DateTimeRange,
-  options?: FormatOptions,
+  options: FormatOptions = {},
 ): string {
   const [from, to] = toTimeSpan(range)
 
@@ -512,7 +508,7 @@ function formatRelativeTimeRange(
   try {
     return formatDate(
       from,
-      options?.dateTimeOptions ?? {
+      options.dateTimeOptions ?? {
         dateStyle: 'long',
         timeStyle: 'short',
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,11 +290,7 @@ function filterMatchers(options?: FormatOptions) {
         (matcher) => matcher[0] === normalizedUnit,
       )
 
-      if (matcherToExcludeIndex === -1) {
-        throw new RangeError(
-          `Value ${unit} out of range for formatTimeDifference options property excludedUnits`,
-        )
-      }
+      if (matcherToExcludeIndex === -1) throwRangeError('excludedUnits', unit)
 
       filteredMatchers.splice(matcherToExcludeIndex, 1)
     }

--- a/src/utils/rounding.ts
+++ b/src/utils/rounding.ts
@@ -1,0 +1,100 @@
+/* eslint-disable no-var, import/no-mutable-exports */
+
+// ICU calls "expand" "up" and "trunc" "down".
+
+/** @returns Always positive decimal part of the number. */
+var toDecimal = (value: number) => Math.abs(value % 1)
+
+var isEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON
+
+var isGreaterOrEqual = (a: number, b: number) => a > b || isEqual(a, b)
+
+var isEven = (value: number) => Math.abs(value) % 2 < 1
+
+var nonZero = (value: number) => (Object.is(value, -0) ? 0 : value)
+
+/** Round towards positive infinity. */
+var ceil = (value: number) => nonZero(Math.ceil(value))
+
+/** Round towards negative infinity. */
+var floor = (value: number) => nonZero(Math.floor(value))
+
+/** Round away from zero. */
+var expand = (value: number) => (value >= 0 ? ceil(value) : floor(value))
+
+/** Round toward zero. */
+var trunc = (value: number) => (value >= 0 ? floor(value) : ceil(value))
+
+/** Ties toward positive infinity */
+var halfCeil = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    return isGreaterOrEqual(decimal, 0.5) ? ceil(value) : floor(value)
+  } else {
+    return decimal > 0.5 ? floor(value) : ceil(value)
+  }
+}
+
+/** Ties toward negative infinity. */
+var halfFloor = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    return decimal > 0.5 ? ceil(value) : floor(value)
+  } else {
+    return isGreaterOrEqual(decimal, 0.5) ? floor(value) : ceil(value)
+  }
+}
+
+/** Ties away from zero. */
+var halfExpand = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    return isGreaterOrEqual(decimal, 0.5) ? ceil(value) : floor(value)
+  } else {
+    return isGreaterOrEqual(decimal, 0.5) ? floor(value) : ceil(value)
+  }
+}
+
+/** Ties towards zero. */
+var halfTrunc = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value > 0) {
+    return decimal > 0.5 ? ceil(value) : floor(value)
+  } else {
+    return decimal > 0.5 ? floor(value) : ceil(value)
+  }
+}
+
+var halfEven = (value: number) => {
+  var decimal = toDecimal(value)
+
+  if (value >= 0) {
+    if (isEqual(decimal, 0.5)) {
+      return isEven(value) ? floor(value) : ceil(value)
+    }
+
+    return decimal > 0.5 ? ceil(value) : floor(value)
+  } else {
+    if (isEqual(decimal, 0.5)) {
+      return isEven(value) ? ceil(value) : floor(value)
+    }
+
+    return decimal > 0.5 ? floor(value) : ceil(value)
+  }
+}
+
+export {
+  ceil,
+  floor,
+  expand,
+  trunc,
+  halfCeil,
+  halfFloor,
+  halfExpand,
+  halfTrunc,
+  halfEven,
+}

--- a/test/data/rounding-samples.ts
+++ b/test/data/rounding-samples.ts
@@ -1,0 +1,695 @@
+export default [
+  {
+    roundingMode: 'ceil',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 3,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 2,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 1,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: 0,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -1,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -2,
+      },
+    ],
+  },
+  {
+    roundingMode: 'floor',
+    samples: [
+      {
+        value: 2.9,
+        result: 2,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 1,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 0,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: -1,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -2,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -3,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'expand',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 3,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 2,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 1,
+      },
+      {
+        value: -0.2,
+        result: -1,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -2,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -3,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'trunc',
+    samples: [
+      {
+        value: 2.9,
+        result: 2,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 1,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 0,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: 0,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -1,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -2,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfCeil',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfFloor',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfExpand',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 3,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 1,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: -1,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -3,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfTrunc',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 1,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -1,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+  {
+    roundingMode: 'halfEven',
+    samples: [
+      {
+        value: 2.9,
+        result: 3,
+      },
+      {
+        value: 2.5,
+        result: 2,
+      },
+      {
+        value: 2.1,
+        result: 2,
+      },
+      {
+        value: 1.8,
+        result: 2,
+      },
+      {
+        value: 1.5,
+        result: 2,
+      },
+      {
+        value: 1.3,
+        result: 1,
+      },
+      {
+        value: 0.7,
+        result: 1,
+      },
+      {
+        value: 0.5,
+        result: 0,
+      },
+      {
+        value: 0.2,
+        result: 0,
+      },
+      {
+        value: -0.2,
+        result: 0,
+      },
+      {
+        value: -0.5,
+        result: 0,
+      },
+      {
+        value: -0.7,
+        result: -1,
+      },
+      {
+        value: -1.3,
+        result: -1,
+      },
+      {
+        value: -1.5,
+        result: -2,
+      },
+      {
+        value: -1.8,
+        result: -2,
+      },
+      {
+        value: -2.1,
+        result: -2,
+      },
+      {
+        value: -2.5,
+        result: -2,
+      },
+      {
+        value: -2.9,
+        result: -3,
+      },
+    ],
+  },
+]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -139,4 +139,20 @@ test('formatTimeDifference (all units excluded)', () => {
   ).toBe('1 січня 2023 р. о 00:00')
 })
 
+test('formatTimeDifference (trunc rounding method)', () => {
+  const twoSthnYearsInPast = now - year * 2.7
+  const twoSthnYearsInFuture = now + year * 2.7
+
+  expect(ago(twoSthnYearsInPast)).toMatchInlineSnapshot('"3 роки тому"')
+  expect(ago(twoSthnYearsInFuture)).toMatchInlineSnapshot('"через 3 роки"')
+
+  expect(
+    ago(twoSthnYearsInPast, { roundingMode: 'trunc' }),
+  ).toMatchInlineSnapshot('"2 роки тому"')
+
+  expect(
+    ago(twoSthnYearsInFuture, { roundingMode: 'trunc' }),
+  ).toMatchInlineSnapshot('"через 2 роки"')
+})
+
 // TODO: more tests + coverage

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -155,4 +155,23 @@ test('formatTimeDifference (trunc rounding method)', () => {
   ).toMatchInlineSnapshot('"через 2 роки"')
 })
 
+test('formatTimeDifference (with unitRounding)', () => {
+  const fiftyNineSthnMinutesAgo = now - 59.6 * minute
+  const twentyThreeSthnHoursInFuture = now + 23.5 * hour
+
+  expect(ago(fiftyNineSthnMinutesAgo)).toMatchInlineSnapshot('"60 хвилин тому"')
+
+  expect(ago(twentyThreeSthnHoursInFuture)).toMatchInlineSnapshot(
+    '"через 24 години"',
+  )
+
+  expect(
+    ago(fiftyNineSthnMinutesAgo, { unitRounding: true }),
+  ).toMatchInlineSnapshot('"1 годину тому"')
+
+  expect(
+    ago(twentyThreeSthnHoursInFuture, { unitRounding: true }),
+  ).toMatchInlineSnapshot('"завтра"')
+})
+
 // TODO: more tests + coverage

--- a/test/rounding.test.ts
+++ b/test/rounding.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import * as roundingModesImpls from '../src/utils/rounding.ts'
+import roundingSamples from './data/rounding-samples.ts'
+
+type RoundingMode = keyof typeof roundingModesImpls
+
+describe('rounding modes', () => {
+  for (const { roundingMode, samples } of roundingSamples) {
+    it(`rounds correctly in "${roundingMode}"`, () => {
+      expect(
+        roundingModesImpls,
+        `${roundingMode} is implemented`,
+      ).toHaveProperty(roundingMode)
+
+      for (const { value, result } of samples) {
+        expect(
+          roundingModesImpls[roundingMode as RoundingMode](value),
+          `Value ${value} is rounded to ${result}`,
+        ).toEqual(result)
+      }
+    })
+  }
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,8 +7,6 @@
     "strict": true,
     "strictBindCallApply": true,
 
-    "verbatimModuleSyntax": true,
-
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "esnext",
     "moduleResolution": "bundler",
 
+    "allowImportingTsExtensions": true,
+
     "types": [],
 
     "outDir": "./dist",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -3,9 +3,21 @@
   "compilerOptions": {
     "composite": true,
 
-    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
 
-    "types": []
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+
+    "types": [],
+
+    "emitDeclarationOnly": true
   },
-  "include": ["./vitest.config.ts", "./test/*.test.ts", "./tsconfig.tests.json"]
+  "include": [
+    "./vitest.config.ts",
+    "./test/*.test.ts",
+    "./test/data/*.ts",
+    "./tsconfig.tests.json",
+    "./src/utils/*.ts"
+  ]
 }


### PR DESCRIPTION
ESLint doesn't really work, especially with TypeScript plugin, so it's not really recommended. As such, this PR removes use of cache from the lint script and CI.