### PR TITLE
fix(docs): clarify that "trunc" will be the new rounding mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Describes a value within the time range that can be used as or converted to a ti
   - `halfTrunc` — round values below or at half-increment towards 0, and values above away from 0.
   - `halfEven` — round values at half-increment towards the nearest even value, values above it away from 0, and values below it towards 0.
 
-  Value of `null` will use `Math.round`. This value is only kept for backward compatibility and will be removed in the next major release, in which `"halfExpand"` will be made the new default.
+  Value of `null` will use `Math.round`. This value is only kept for backward compatibility and will be removed in the next major release, in which `"trunc"` will be made the new default.
 
   **Default**: `null`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export interface FormatOptions extends FormatRelativeTimeOptions {
    *
    * Value of `null` will use `Math.round`. This value is only kept for backward
    * compatibility, and will be removed in the next major release, in which
-   * `"halfExpand"` will be made a new default.
+   * `"trunc"` will be made a new default.
    *
    * @default null // Use `Math.round` (deprecated)
    */


### PR DESCRIPTION
After re-consideration, the `"trunc"` will be the new default rounding mode, rather than the `"halfExpand"`, as it was previously mentioned in the docs. `"trunc"` makes a lot more sense for the relative time, which should answer the questions ‘how much time has passed since something?‘ or ‘how much time before somethig happens?’ *exactly* by default. If that's not the question, package consumers can set `roundingMode` to `"halfExpand"`, which is a good rounding mode to give *approximations*, e.g., ‘something is going to happen in about a minute’.